### PR TITLE
fix: remove typo in setting 'Igonre' to 'Ignore'

### DIFF
--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -236,7 +236,7 @@ export class AutomaticLinkerPluginSettingsTab extends PluginSettingTab {
             })
 
         new Setting(containerEl)
-            .setName("Igonre domains")
+            .setName("Ignore domains")
             .setDesc(
                 "Ignore domains for replacing URLs with titles, one per line (e.g. x.com)",
             )


### PR DESCRIPTION
Hi,

found a small typo while testing this plugin in the settings.
Here's a fix.

Cheers!
Daniel